### PR TITLE
Discussion - Is it a request to validate or an event?

### DIFF
--- a/NoDuplicatesDesigns/10_AggregateWithMediatR/Catalog.cs
+++ b/NoDuplicatesDesigns/10_AggregateWithMediatR/Catalog.cs
@@ -29,7 +29,7 @@ namespace NoDuplicatesDesigns._10_AggregateWithMediatR
             if (Products.Any(p => p.Name == newName)) throw new System.Exception("Duplicate name.");
         }
 
-        public class ProductNameChangeHandler : INotificationHandler<ProductNameChangeRequested>
+        public class ProductNameChangeHandler : IRequestHandler<ProductNameValidationRequest>
         {
             private readonly CatalogRepository _catalogRepository;
 
@@ -38,14 +38,15 @@ namespace NoDuplicatesDesigns._10_AggregateWithMediatR
                 _catalogRepository = catalogRepository;
             }
 
-            public Task Handle(ProductNameChangeRequested notification, CancellationToken cancellationToken)
+            public Task<Unit> Handle(ProductNameValidationRequest request, CancellationToken cancellationToken)
             {
-                var catalog = _catalogRepository.GetById(notification.Product.CatalogId);
-                if (catalog.Products.Any(p => p.Id == notification.Product.Id))
+                var catalog = _catalogRepository.GetById(request.Product.CatalogId);
+                if (catalog.Products.Any(p => p.Id == request.Product.Id))
                 {
-                    catalog.ValidateNameNotAlreadyInUse(notification.NewName);
+                    catalog.ValidateNameNotAlreadyInUse(request.NewName);
                 }
-                return Task.CompletedTask;
+
+                return Unit.Task;
             }
         }
     }

--- a/NoDuplicatesDesigns/10_AggregateWithMediatR/DomainEvents.cs
+++ b/NoDuplicatesDesigns/10_AggregateWithMediatR/DomainEvents.cs
@@ -4,13 +4,18 @@ using System.Threading.Tasks;
 
 namespace NoDuplicatesDesigns._10_AggregateWithMediatR
 {
-    public static class DomainEvents
+    public static class DomainActions
     {
         public static Func<IMediator> Mediator { get; set; }
-        public static async Task Raise<T>(T args) where T : INotification
+        public static async Task RaiseEvent<T>(T args) where T : INotification
         {
             var mediator = Mediator.Invoke();
             await mediator.Publish<T>(args);
+        }
+        public static async Task ValidationRequest<T>(T args) where T : IRequest
+        {
+            var mediator = Mediator.Invoke();
+            await mediator.Send(args);
         }
     }
 }

--- a/NoDuplicatesDesigns/10_AggregateWithMediatR/Product.cs
+++ b/NoDuplicatesDesigns/10_AggregateWithMediatR/Product.cs
@@ -16,7 +16,7 @@
         public void UpdateName(string newName)
         {
             if (Name == newName) return;
-            DomainEvents.Raise(new ProductNameChangeRequested(this, newName)).GetAwaiter().GetResult();
+            DomainActions.ValidationRequest(new ProductNameValidationRequest(this, newName)).GetAwaiter().GetResult();
             Name = newName;
         }
     }

--- a/NoDuplicatesDesigns/10_AggregateWithMediatR/ProductNameValidationRequest.cs
+++ b/NoDuplicatesDesigns/10_AggregateWithMediatR/ProductNameValidationRequest.cs
@@ -2,9 +2,9 @@
 
 namespace NoDuplicatesDesigns._10_AggregateWithMediatR
 {
-    public class ProductNameChangeRequested : INotification
+    public class ProductNameValidationRequest : IRequest
     {
-        public ProductNameChangeRequested(Product product, string newName)
+        public ProductNameValidationRequest(Product product, string newName)
         {
             Product = product;
             NewName = newName;

--- a/NoDuplicatesDesigns/10_AggregateWithMediatR/ProductUpdateNameTests.cs
+++ b/NoDuplicatesDesigns/10_AggregateWithMediatR/ProductUpdateNameTests.cs
@@ -24,14 +24,14 @@ namespace NoDuplicatesDesigns._10_AggregateWithMediatR
         private void SetUpMediatR()
         {
             _serviceProvider = BuildServiceProvider();
-            DomainEvents.Mediator = () => BuildMediator(_serviceProvider);
+            DomainActions.Mediator = () => BuildMediator(_serviceProvider);
         }
 
         private ServiceProvider BuildServiceProvider()
         {
             var services = new ServiceCollection();
 
-            services.AddMediatR(typeof(DomainEvents));
+            services.AddMediatR(typeof(DomainActions));
             services.AddSingleton(_catalogRepository);
 
             return services.BuildServiceProvider();


### PR DESCRIPTION
Hey Steve,

First off this isn't a real PR. More of a discussion. I felt like it was easier to explain what I meant in a PR form with code than if I opened an issue.

My main use for MediatR has been to thin out my controllers. Each API request maps itself to a MediatR request and that handler figures out how to answer that very specific response with only using the dependencies that request requires. _Essentially the controller is asking the handler to fill the request and provide the information (or exception) before it proceeds further._ If I feel like it, I could put all of those requests and handlers into a library and abstract the host (Webapi, background service, whatever) away from the job being done. Fantastic abstraction. Magical, I love it. 

On the other hand, when I hear the word event, I think of something that happened in the past and that it can be handled at some point in the future. It doesn't have to be immediate. I haven't used the notification mechanism in MediatR as much because of its transactional nature for this reason and have used Event Stores or pub/sub mechanisms for it.

So with that context, it felt off to me to use an event for validation. _Essentially the domain aggregate is asking the handler to fill the request and provide the information (or exception) before it proceeds further._ This _feels_ to me to be more like the request mechanism than the notification mechanism similar to the controller above.

I know you've had the DomainEvents class forever as I have seen it in the pluralsight courses from forever ago so I'm not surprised at all to see you use it in this mechanism, because frankly this works perfectly. It's only the language of raising an event vs requesting a specific action right now that I struggled with.

Anyways, just curious what your thoughts are on the send request vs notify/raise type language.