### PR TITLE
fix the CatalogRepository in [Use an Aggregate with Double Dispatch] and its unit testing

### DIFF
--- a/NoDuplicatesDesigns/08_AggregateWithDblDispatch/CatalogRepository.cs
+++ b/NoDuplicatesDesigns/08_AggregateWithDblDispatch/CatalogRepository.cs
@@ -16,7 +16,7 @@ namespace NoDuplicatesDesigns._08_AggregateWithDoubleDispatch
 
             foreach (var product in catalog.Products)
             {
-                newCatalog.Products.Add(new Product(product.Name) { Id = product.Id });
+                newCatalog.Products.Add(new Product(product.Name) { Id = product.Id, CatalogId = catalog.Id });
             }
             return newCatalog;
         }

--- a/NoDuplicatesDesigns/08_AggregateWithDblDispatch/CatalogUpdateProductNameTests.cs
+++ b/NoDuplicatesDesigns/08_AggregateWithDblDispatch/CatalogUpdateProductNameTests.cs
@@ -20,8 +20,8 @@ namespace NoDuplicatesDesigns._08_AggregateWithDoubleDispatch
         private void SeedData()
         {
             var catalog = new Catalog() { Id = TEST_CATALOG_ID };
-            catalog.Products.Add(new Product(TEST_NAME) { Id = TEST_ID1 });
-            catalog.Products.Add(new Product(Guid.NewGuid().ToString()) { Id = TEST_ID2 });
+            catalog.Products.Add(new Product(TEST_NAME) { Id = TEST_ID1, CatalogId = TEST_CATALOG_ID });
+            catalog.Products.Add(new Product(Guid.NewGuid().ToString()) { Id = TEST_ID2, CatalogId = TEST_CATALOG_ID });
             _catalogRepository.Add(catalog);
         }
 


### PR DESCRIPTION
Hi 
When I run all testing in solution, I find the ProductUpdateNameTests of NoDuplicatesDesigns._08_AggregateWithDoubleDispatch can't pass UpdatesNameGivenNewUniqueName/ThrowsExceptionGivenDuplicateName testing.

The reason is CatalogRepository didn't create correct Product instances because of lost CatalogId.

Please review the modification, thanks.